### PR TITLE
[EINT-494] Add `mobile-integrations` as code owners of the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ROKT/ecommerce
+* @ROKT/mobile-integrations


### PR DESCRIPTION
### Background ###

We have split the ecommerce team into 3 separate [teams (https://rokt.atlassian.net/wiki/spaces/ENG/pages/2358247495/RPD+Teams). 
This PR adds mobile-integrations as code owners of this repo.

Fixes [([issue](https://rokt.atlassian.net/browse/EINT-494))]

### What Has Changed: ###

- removed `ecommerce` as code owners of this repo
- added `mobile-integrations` as code owners of this repo

### How Has This Been Tested? ###

Project runs without errors.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.